### PR TITLE
Use "simple" quotes to avoid an encoding problem while installing on Win...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ The C# language provides a handy way to declare, subscribe to and fire events.
 Technically, an event is a "slot" where callback functions (event handlers) can
 be attached to - a process referred to as subscribing to an event. Here is
 a handy package that encapsulates the core to event subscription and event
-firing and feels like a “natural” part of the language.
+firing and feels like a "natural" part of the language.
 
 .. code-block:: pycon
  


### PR DESCRIPTION
...dows (issue #2)
