### PR TITLE
Add support for defining event names in constructor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Patches and Suggestions
 - Eric Smith
 - Evan Klitzke
 - Thomas Hanssen Nornes
+- Anfernee Jervis

--- a/events/events.py
+++ b/events/events.py
@@ -35,14 +35,32 @@ class Events:
 
             xxx.OnChange = event('OnChange')
     """
+    def __init__(self, events=None):
+
+        if events is not None:
+
+            try:
+                for _ in events:
+                    break
+            except:
+                raise AttributeError("type object %s is not iterable" %
+                                      (type(events)))
+            else:
+                self.__events__ = events
+
     def __getattr__(self, name):
         if name.startswith('__'):
             raise AttributeError("type object '%s' has no attribute '%s'" %
                                  (self.__class__.__name__, name))
 
+        if hasattr(self, '__events__'):
+            if name not in self.__events__:
+                raise EventsException("Event '%s' is not declared" % name)
+
         if hasattr(self.__class__, '__events__'):
             if name not in self.__class__.__events__:
                 raise EventsException("Event '%s' is not declared" % name)
+
         self.__dict__[name] = ev = _EventSlot(name)
         return ev
 

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -98,3 +98,27 @@ class TestEventSlot(TestBase):
         self.assertEqual(len(ev), 2)
         self.assertEqual(ev[0].__name__, 'callback2')
         self.assertEqual(ev[1].__name__, 'callback3')
+
+
+class TestInstanceEvents(TestBase):
+
+    def test_getattr(self):
+
+        MyEvents = Events(('on_eventOne', ))
+
+        try:
+            MyEvents.on_eventOne += self.callback1
+        except:
+            self.fail("Exception raised but not expected.")
+
+        try:
+            MyEvents.on_eventNotOne += self.callback1
+        except EventsException:
+            pass
+        else:
+            self.fail("'EventsException' excpected and not raised.")
+
+        try:
+            self.events.on_eventNotOne += self.callback1
+        except:
+            self.fail("Exception raised but not expected.")


### PR DESCRIPTION
Resolves #1 

- Events that are initialized by a list/tuple of event names,
will have those names stored in __events__, local to that instance only.

- Both __events__ and __class__.__events__ will be evaluated, long as they
exist. 

It is not recommended to use both the constructor method and the `__events__` class variable simultaneously.