### PR TITLE
Add event_slot_cls argument to Events to allow custom EventSlot class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Patches and Suggestions
 - Evan Klitzke
 - Michael Kennedy
 - Thomas Hanssen Nornes
+- Øyvind Heddeland Instefjord

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ In development
 --------------
 
 - Add section on unsubscribing to documentation (Michael Kennedy)
+- Fix Events.__len__ counting __events__
+- Add event_slot_cls argument to Events to allow custom EventSlot class.
 
 Version 0.3
 -----------

--- a/events/events.py
+++ b/events/events.py
@@ -72,7 +72,7 @@ class Events:
     __str__ = __repr__
 
     def __len__(self):
-        return len(self.__dict__.items())
+        return len(list(self.__iter__()))
 
     def __iter__(self):
         def gen(dictitems=self.__dict__.items()):

--- a/events/events.py
+++ b/events/events.py
@@ -69,7 +69,8 @@ class Events:
 
             xxx.OnChange = event('OnChange')
     """
-    def __init__(self, events=None):
+    def __init__(self, events=None, event_slot_cls=_EventSlot):
+        self.__event_slot_cls__ = event_slot_cls
 
         if events is not None:
 
@@ -95,7 +96,7 @@ class Events:
             if name not in self.__class__.__events__:
                 raise EventsException("Event '%s' is not declared" % name)
 
-        self.__dict__[name] = ev = _EventSlot(name)
+        self.__dict__[name] = ev = self.__event_slot_cls__(name)
         return ev
 
     def __repr__(self):
@@ -111,6 +112,6 @@ class Events:
     def __iter__(self):
         def gen(dictitems=self.__dict__.items()):
             for attr, val in dictitems:
-                if isinstance(val, _EventSlot):
+                if isinstance(val, self.__event_slot_cls__):
                     yield val
         return gen()

--- a/events/events.py
+++ b/events/events.py
@@ -14,6 +14,40 @@
 """
 
 
+class _EventSlot:
+    def __init__(self, name):
+        self.targets = []
+        self.__name__ = name
+
+    def __repr__(self):
+        return "event '%s'" % self.__name__
+
+    def __call__(self, *a, **kw):
+        for f in tuple(self.targets):
+            f(*a, **kw)
+
+    def __iadd__(self, f):
+        self.targets.append(f)
+        return self
+
+    def __isub__(self, f):
+        while f in self.targets:
+            self.targets.remove(f)
+        return self
+
+    def __len__(self):
+        return len(self.targets)
+
+    def __iter__(self):
+        def gen():
+            for target in self.targets:
+                yield target
+        return gen()
+
+    def __getitem__(self, key):
+        return self.targets[key]
+
+
 class EventsException(Exception):
     pass
 
@@ -80,37 +114,3 @@ class Events:
                 if isinstance(val, _EventSlot):
                     yield val
         return gen()
-
-
-class _EventSlot:
-    def __init__(self, name):
-        self.targets = []
-        self.__name__ = name
-
-    def __repr__(self):
-        return "event '%s'" % self.__name__
-
-    def __call__(self, *a, **kw):
-        for f in tuple(self.targets):
-            f(*a, **kw)
-
-    def __iadd__(self, f):
-        self.targets.append(f)
-        return self
-
-    def __isub__(self, f):
-        while f in self.targets:
-            self.targets.remove(f)
-        return self
-
-    def __len__(self):
-        return len(self.targets)
-
-    def __iter__(self):
-        def gen():
-            for target in self.targets:
-                yield target
-        return gen()
-
-    def __getitem__(self, key):
-        return self.targets[key]

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -54,6 +54,30 @@ class TestEvents(TestBase):
             self.assertTrue(isinstance(event, events.events._EventSlot))
         self.assertEqual(i, 2)
 
+    def test_iter_custom_event_slot_cls(self):
+        class CustomEventSlot(events.events._EventSlot):
+            pass
+        self.events = Events(event_slot_cls=CustomEventSlot)
+        self.events.on_change += self.callback1
+        self.events.on_change += self.callback2
+        self.events.on_edit += self.callback1
+        i = 0
+        for event in self.events:
+            i += 1
+            self.assertTrue(isinstance(event, CustomEventSlot))
+        self.assertEqual(i, 2)
+
+    def test_event_slot_cls_default(self):
+        self.assertEqual(
+            events.events._EventSlot, self.events.__event_slot_cls__)
+
+    def test_event_slot_cls_custom(self):
+        class CustomEventSlot(events.events._EventSlot):
+            pass
+
+        custom = Events(event_slot_cls=CustomEventSlot)
+        self.assertEqual(CustomEventSlot, custom.__event_slot_cls__)
+
 
 class TestEventSlot(TestBase):
     def setUp(self):

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -37,6 +37,9 @@ class TestEvents(TestBase):
             self.fail("Exception raised but not expected.")
 
     def test_len(self):
+        # We want __events__ to be set to verify that it is not counted as
+        # part of __len__.
+        self.events = Events(events=("on_change", "on_get"))
         self.events.on_change += self.callback1
         self.events.on_get += self.callback2
         self.assertEqual(len(self.events), 2)


### PR DESCRIPTION
Came upon a special case in my use of the Events class on Friday that would ideally be fixed by creating a custom EventSlot class. There were no good way to do that so here is a PR adding that capability :)  

I also fixed a bug with the ``__len__`` method in the Events class. It would count ``__events__``, and now also ``__event_slot_cls__``, which isn't what you would expect.