### PR TITLE
Added __getitem__ dunder to Events class

### DIFF
--- a/events/events.py
+++ b/events/events.py
@@ -99,6 +99,9 @@ class Events:
         self.__dict__[name] = ev = self.__event_slot_cls__(name)
         return ev
 
+    def __getitem__(self, item):
+        return self.__dict__[item]
+
     def __repr__(self):
         return '<%s.%s object at %s>' % (self.__class__.__module__,
                                          self.__class__.__name__,

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -118,6 +118,14 @@ class TestEventSlot(TestBase):
             pass
         else:
             self.fail("IndexError expected.")
+        self.assertIs(ev, self.events["on_edit"])
+        self.assertIsNot(ev, self.events["on_change"])
+        try:
+            self.events["on_nonexistent_event"]
+        except KeyError:
+            pass
+        else:
+            self.fail("KeyError expected.")
 
     def test_isub(self):
         self.events.on_change -= self.callback1


### PR DESCRIPTION
Added `__getitem__` dunder to Events class. This allows the calling of events from strings, thus enabling dynamic events. For instance:

```
events = Events(tuple(f"on_{i}" for i in range(5)))

for i in range(5):
    events[f"on_{i}"](i)
```
