### PR TITLE
Add population of `__dict__` variable with `__events__`, if present.

### DIFF
--- a/events/events.py
+++ b/events/events.py
@@ -69,11 +69,11 @@ class Events:
 
             xxx.OnChange = event('OnChange')
     """
+
     def __init__(self, events=None, event_slot_cls=_EventSlot):
         self.__event_slot_cls__ = event_slot_cls
 
         if events is not None:
-
             try:
                 for _ in events:
                     break
@@ -82,6 +82,12 @@ class Events:
                                      (type(events)))
             else:
                 self.__events__ = events
+
+        if hasattr(self, '__events__'):
+            self.__dict__ = dict(
+                {name: self.__event_slot_cls__(name) for name in self.__events__},
+                **self.__dict__
+            )
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/events/tests/tests.py
+++ b/events/tests/tests.py
@@ -118,6 +118,13 @@ class TestEventSlot(TestBase):
             pass
         else:
             self.fail("IndexError expected.")
+
+    def test_getitem_bystring(self):
+
+        class MyEvents(Events):
+            __events__ = ('on_event_one', 'on_event_two')
+
+        ev = self.events.on_edit
         self.assertIs(ev, self.events["on_edit"])
         self.assertIsNot(ev, self.events["on_change"])
         try:
@@ -126,6 +133,32 @@ class TestEventSlot(TestBase):
             pass
         else:
             self.fail("KeyError expected.")
+        my_events = MyEvents()
+        self.assertIs(my_events.on_event_one, my_events["on_event_one"])
+        self.assertIs(my_events.on_event_two, my_events["on_event_two"])
+        try:
+            my_events["on_nonexistent_event"]
+        except KeyError:
+            pass
+        else:
+            self.fail("KeyError expected.")
+        events = Events()
+        try:
+            events["on_event_one"]
+        except KeyError:
+            pass
+        else:
+            self.fail("KeyError expected.")
+        events = Events(("on_event_three", "on_event_four"))
+        self.assertIs(events.on_event_three, events["on_event_three"])
+        self.assertIs(events.on_event_four, events["on_event_four"])
+        try:
+            events["on_event_one"]
+        except KeyError:
+            pass
+        else:
+            self.fail("KeyError expected.")
+
 
     def test_isub(self):
         self.events.on_change -= self.callback1


### PR DESCRIPTION
I added the population of the `__dict__` variable with `__events__` (if present), when the `Events` class is instantiated.

I did this as I noticed an issue where events could be accessed via strings (e.g., `events["on_my_event"]`) only if they had previously been accessed directly (i.e., though `__getattr__`), which added them to the `__dict__` variable. This fix works both for cases of direct `Events` class instantiation (e.g., `events = Events(("on_one", "on_two"))` and subclassing
(e.g.,
```
class MyEvents(Events):
    __events__ = ("on_one", "on_two")
```
).

Note, the new `__dict__` variable is generated in the way it is (rather than just in a for loop) for two reasons:
1. `timeit` indicated it was (albeit only very slightly) faster
2. This method is safer in that it will never overwrite a key in the original dictionary if there happens to be a collision.